### PR TITLE
Only refresh when server responds with 401.

### DIFF
--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -83,7 +83,7 @@ class TokenPool {
       });
       console.warn(`Adding ${res.length} tokens to acquired pool`);
       this.tokens.push(...res);
-    } else {
+    } else if (response.status === 401){
       // refresh the access token. This will call generateTokens if the refresh is successful
       AccessToken.refresh();
     }


### PR DESCRIPTION
401 error is sent when the access token expires. 402 if the user is not a subscriber. This change prevents access token refresh spam when users are no plus or premium.