### PR TITLE
Fix: Refresh access_token if expired

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -11,12 +11,7 @@ class AccessToken {
     tokenPool.generateTokens();
   }
 
-  static async get() {
-    const token = AccessToken.TOKEN;
-    if (token) {
-      return token;
-    }
-    await AccessToken.refresh();
+  static get() {
     return AccessToken.TOKEN;
   }
 
@@ -55,6 +50,9 @@ const cookieListener = (changeInfo) => {
 
   if (removed) {
     AccessToken.destroy();
+    // try to refresh the token incase remove was caused by
+    // token expiring
+    AccessToken.refresh();
     return;
   }
 
@@ -69,6 +67,10 @@ const lookForAccessToken = async () => {
   });
   if (cookie) {
     AccessToken.set(cookie.value);
+  } else {
+    // if token is not found on startup try to refresh
+    // as it can just be expired
+    AccessToken.refresh();
   };
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -12,11 +12,12 @@ class AccessToken {
   }
 
   static async get() {
-    if (AccessToken.TOKEN) {
-      return AccessToken.TOKEN
+    const token = AccessToken.TOKEN;
+    if (token) {
+      return token;
     }
     await AccessToken.refresh();
-    return AccessToken.TOKEN
+    return AccessToken.TOKEN;
   }
 
   static destroy() {

--- a/src/background.js
+++ b/src/background.js
@@ -11,8 +11,12 @@ class AccessToken {
     tokenPool.generateTokens();
   }
 
-  static get() {
-    return AccessToken.TOKEN;
+  static async get() {
+    if (AccessToken.TOKEN) {
+      return AccessToken.TOKEN
+    }
+    await AccessToken.refresh();
+    return AccessToken.TOKEN
   }
 
   static destroy() {

--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -39,7 +39,7 @@ class TokenPool {
   }
 
   async generateTokens() {
-    const accessToken = AccessToken.get();
+    const accessToken = await AccessToken.get();
     if (!accessToken) {
       return;
     }

--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -40,7 +40,7 @@ class TokenPool {
   }
 
   async generateTokens() {
-    // avoid exponential growth of the token pool
+    // avoid endless growth of the token pool
     if (this.tokens.length >= MIN_TOKENS) {
       return;
     }

--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -1,4 +1,5 @@
 const PUBLIC_EXP = 65537;
+const MIN_TOKENS = 6;
 
 function bnToBase64(bn) {
   return sjcl.codec.base64.fromBits(bn.toBits());
@@ -16,7 +17,7 @@ class TokenPool {
   async getToken() {
     if (this.tokens.length === 0) {
       await this.generateTokens();
-    } else if (this.tokens.length < 6) {
+    } else if (this.tokens.length < MIN_TOKENS) {
       this.generateTokens();
     }
     return this.tokens.pop();
@@ -39,6 +40,11 @@ class TokenPool {
   }
 
   async generateTokens() {
+    // avoid exponential growth of the token pool
+    if (this.tokens.length >= MIN_TOKENS) {
+      return;
+    }
+
     const accessToken = AccessToken.get();
     if (!accessToken) {
       return;

--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -89,6 +89,9 @@ class TokenPool {
       });
       console.warn(`Adding ${res.length} tokens to acquired pool`);
       this.tokens.push(...res);
+    } else if (response.status === 401) {
+      // refresh the access token. This will call generateTokens if the refresh is successful
+      AccessToken.refresh();
     }
   }
 }

--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -63,7 +63,6 @@ class TokenPool {
         blindTokens,
       }),
     });
-
     if (response.ok) {
       const { tokens } = await response.json();
       const res = [];

--- a/src/token-pool.js
+++ b/src/token-pool.js
@@ -59,6 +59,9 @@ class TokenPool {
       // as the token technically could have expired by the time the request
       // arives
       const accessToken = await AccessToken.get();
+      if (!accessToken) {
+        return;
+      }
       response = await this._fetchNewTokens(accessToken, blindTokens);
     }
     if (response.ok) {


### PR DESCRIPTION
The browser removes the access_token if expired however it's likely we have a refresh_token available to get a new one, so rather than failing and prompting the user to sign in again, we can just try to renew here first.