### PR TITLE
don't refresh on overwrite

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -39,7 +39,7 @@ function parseJwt(token) {
 };
 
 const cookieListener = (changeInfo) => {
-  const { cookie, removed } = changeInfo;
+  const { cookie, removed, cause } = changeInfo;
   if (cookie.domain !== AUTH_DOMAIN) {
     return;
   }
@@ -50,9 +50,13 @@ const cookieListener = (changeInfo) => {
 
   if (removed) {
     AccessToken.destroy();
-    // try to refresh the token incase remove was caused by
-    // token expiring
-    AccessToken.refresh();
+
+    if (cause !== "overwrite") {
+      // try to refresh the token incase remove was caused by
+      // token expiring
+      AccessToken.refresh();
+    }
+
     return;
   }
 


### PR DESCRIPTION
Refreshing on overwrite could cause the extension to keep trying to refresh the token when it does not need to,  @sammacbeth not 100% sure but we might want to also not destroy it if the remove cause is overwrite as well?