### PR TITLE
fix: remove unnecessary permissions, and update manifest files

### DIFF
--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -13,11 +13,6 @@
   },
   "manifest_version": 3,
   "name": "Ghostery Private Search for Chrome",
-  "permissions": [
-    "tabs"
-  ],
-  "host_permissions": [
-  ],
   "icons": {
     "16": "./icons/icon16.png",
     "48": "./icons/icon48.png",

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -17,13 +17,11 @@
       "48": "./icons/icon48.png",
       "128": "./icons/icon128.png"
     },
+    "default_area": "navbar",
     "default_title": "Ghostery Private Search"
   },
   "manifest_version": 2,
   "name": "Ghostery Private Search for Firefox",
-  "permissions": [
-    "tabs"
-  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostery-search-extension",
-  "version": "1.1.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostery-search-extension",
-      "version": "1.1.0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "devDependencies": {
         "web-ext": "^8.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostery-search-extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The `tabs` permission isn't required to use the `chrome.tabs.create` API. I checked both Chrome and Firefox, and the icon correctly opens the search page.